### PR TITLE
Don't escape Discord formatting characters in URLs

### DIFF
--- a/src/handler/discord.js
+++ b/src/handler/discord.js
@@ -73,7 +73,7 @@ module.exports = class {
 						const mapped_username = `${event.type == "minetest" ? "" : "@" + event.name}`;
 						// escape formatting characters
 						const escaped_username = event.username.replace(/([*_`~|])/g, "\\$1");
-						const escaped_message = event.message.replace(/([*_`~|])/g, "\\$1");
+						const escaped_message = event.message.replace(/(?<!https?:\/\/\S*)([*_`~|])/g, "\\$1");
 
 						if (event.message_type == "me"){
 							// me message


### PR DESCRIPTION
When backslashes are in a URL in Discord, it changes them to forward when displayed, resulting in invalid URLs like https://github.com/minetest-beerchat/beerchat/_proxy when there are escaped characters.